### PR TITLE
[Proposal] Include a `t` function

### DIFF
--- a/packages/core/src/utils/t.ts
+++ b/packages/core/src/utils/t.ts
@@ -1,0 +1,44 @@
+const hbs = /{{\s*([^}}\s]*)\s*}}/g;
+
+export type Replacements = {
+  count?: number,
+  [k: string]: any
+};
+
+export type TOptions = {
+  dictionary? :HTMLIntlDictionaryElement;
+  pluralizer?: Intl.PluralRulesOptions;
+}
+
+function pluralSuffix(replacements: Replacements, locale: string, options: Intl.PluralRulesOptions): string {
+  if (!replacements.hasOwnProperty('count')) {
+    return '';
+  }
+
+  let formatter = new Intl.PluralRules(locale, options || {});
+
+  return `.${formatter.select(replacements.count)}`;
+}
+
+export async function t(name: string, replacements: Replacements = {}, options: TOptions = {}): Promise<string | false> {
+  let { dictionary } = options;
+  if (!dictionary) {
+    dictionary = await document.querySelector('intl-dictionary').componentOnReady();
+  }
+
+  let suffix = pluralSuffix(replacements, dictionary.lang, options.pluralizer);
+
+  let phrase = await dictionary.resolvePhrase(`${name}${suffix}`);
+
+  if (phrase === false) {
+    return false;
+  }
+
+  return phrase.replace(hbs, (matched, ident) => {
+    if (ident in replacements) {
+      return replacements[ident].toString();
+    }
+
+    return matched;
+  });
+}


### PR DESCRIPTION
The t function helps localizing strings where the component cannot be
used. Some examples are:

- You need a list of localized strings alphabetically sorted.
- Want to use as text in an ion-select.
- Want to use as parameters of other functions (date formatting, as an
example).

It follows a few conventions I saw in many other libraries through the
years, while leaving others I'm not sure how I want them implemented
yet.

The main one is using the parameter `count` in replacements as the way
to pluralize the string. If a `count` field is found, we look for
a pluralize suffix. That is, to the key being used, we'll append the
result of running the `select` method to the `count` parameter. (Getting
the `locale` can certainly be improved, and maybe would need to be moved
to dictionary.